### PR TITLE
Refactor/async-await-migration

### DIFF
--- a/Travl.iOS/Model/Networking/Interactor/DiscoverInteractor.swift
+++ b/Travl.iOS/Model/Networking/Interactor/DiscoverInteractor.swift
@@ -16,32 +16,14 @@ enum Endpoint : String {
 final class DiscoverInteractor {
     private let networkManager = NetworkManager()
     
-    func fetchLocations(completion : @escaping ((Result<LocationsResponse,TError>)->Void)) {
-        networkManager.fetchData(endpoint: .location) {  (_ result : Result<LocationsResponse, TError>) in
-            switch result {
-            case .success(let data):
-                completion(.success(data))
-            case .failure(let error):
-                completion(.failure(.invalidData))
-                print("Error : \(error.localizedDescription)")
-            }
-        }
+    func fetchLocations() async throws -> LocationsResponse {
+        let location : LocationsResponse = try await networkManager.fetchData(endpoint: .location, queryString: "")
+        return location
     }
     
-    func fetchItenaries(_ location : String, completion : @escaping ((Result<[[Days]],TError>)-> Void)) {
-        networkManager.fetchData(endpoint: .itenaries, queryString: location) { (_ result : Result<Itenaries, TError>) in
-            var itenaryCollection = [[Days]]()
-            switch result {
-            case .success(let data):
-                print(data)
-                for itenaryPerDays in data.itenaries.days {
-                    itenaryCollection.append(itenaryPerDays)
-                }
-                completion(.success(itenaryCollection))
-            case .failure(let error):
-                completion(.failure(.invalidData))
-                print("Error : \(error.localizedDescription)")
-            }
-        }
+    func fetchItenaries(_ location : String) async throws -> Itenaries {
+        let itenaries : Itenaries = try await networkManager.fetchData(endpoint: .itenaries, queryString: location)
+        return itenaries
     }
 }
+

--- a/Travl.iOS/Model/Networking/Interactor/PlannerInteractor.swift
+++ b/Travl.iOS/Model/Networking/Interactor/PlannerInteractor.swift
@@ -11,16 +11,8 @@ final class PlannerInteractor {
     //MARK: - Variables
     private let networkManager = NetworkManager()
     
-    func fetchFooterImages(completion :@escaping ((Result<ImagesResponse, TError>)->Void)) {
-        networkManager.fetchData(endpoint: .images) { (_ result : Result<ImagesResponse, TError>) in
-            switch result {
-            case .success(let data):
-                print("Image Data : \(data.images)")
-                completion(.success(data))
-            case .failure(let error):
-                print("ERROR : \(error.localizedDescription)")
-                completion(.failure(error))
-            }
-        }
+    func fetchFooterImages()async throws -> ImagesResponse {
+        let imageResponse : ImagesResponse = try await networkManager.fetchData(endpoint: .images, queryString: "")
+        return imageResponse
     }
 }

--- a/Travl.iOS/Model/Networking/NetworkManager.swift
+++ b/Travl.iOS/Model/Networking/NetworkManager.swift
@@ -12,33 +12,45 @@ final class NetworkManager {
     private let baseURL = "https://travl-api.herokuapp.com/"
     
     //MARK: - Generic Decoded Methods
-    func fetchData<T:Decodable>(endpoint : Endpoint, queryString : String = "",completion : @escaping ((Result<T, TError>)->Void)) {
-        let urlString = ( baseURL + "\(endpoint.rawValue)" + queryString).addingPercentEncoding(withAllowedCharacters: .urlFragmentAllowed)!
-        guard let url = URL(string: urlString) else {return}
-        print("URL for \(endpoint.rawValue) : \(url)")
-        let task = URLSession.shared.dataTask(with: url) { data, response, error in
-            if let _ = error {
-                completion(.failure(.unableToComplete))
-                return
-            }
-            guard let response = response as? HTTPURLResponse, response.statusCode == 200 else {
-                completion(.failure(.invalidResponse))
-                return
-            }
-            
-            guard let safeData = data else {
-                completion(.failure(.invalidData))
-                return
-            }
-            do {
-                let decodedObject = try JSONDecoder().decode(T.self, from: safeData)
-                completion(.success(decodedObject))
-            } catch {
-                completion(.failure(.invalidData))
-                print(error.localizedDescription)
-            }
+    func fetchData<T:Decodable>(endpoint : Endpoint, queryString query: String) async throws -> T {
+        
+        let urlString = ( baseURL + "\(endpoint.rawValue)" + query).addingPercentEncoding(withAllowedCharacters: .urlFragmentAllowed)!
+        guard let url = URL(string: urlString) else {
+            throw TError.invalidTopic
         }
-        task.resume()
+        
+        let (data, _) = try await URLSession.shared.data(from: url)
+        
+        do {
+            let decodedObject = try JSONDecoder().decode(T.self, from: data)
+            return decodedObject
+        } catch {
+            throw TError.invalidData
+        }
+    }
+}
+
+/// Extend backward compatibility for URLSession Async API
+extension URLSession {
+    /// Although Swift 5.5’s new concurrency system is becoming backward compatible in Xcode 13.2,
+    /// some of the built-in system APIs that make use of these new concurrency features are still only available on iOS 15, macOS Monterey, and the rest of Apple’s 2021 operating systems.
+    @available(iOS, deprecated: 15.0, message: "Use this built in API instead")
+    func data(from url : URL) async throws -> (Data, URLResponse) {
+        return try await withCheckedThrowingContinuation({ continuation in
+            let dataTask = self.dataTask(with: url) { data, response, error in
+                if let error = error {
+                    return continuation.resume(throwing: error)
+                }
+                
+                guard let data = data,
+                      let response = response as? HTTPURLResponse ,
+                      response.statusCode == 200 else {
+                    return continuation.resume(throwing: TError.invalidData)
+                }
+                continuation.resume(returning: (data, response))
+            }
+            dataTask.resume()
+        })
     }
 }
 

--- a/Travl.iOS/Module/Discover/Presenter/BaseDiscoverPresenter.swift
+++ b/Travl.iOS/Module/Discover/Presenter/BaseDiscoverPresenter.swift
@@ -21,16 +21,18 @@ final class BaseDiscoverPresenter {
     func setViewDelegate(delegate : BaseDiscoverPresenterDelegate) {
         self.delegate = delegate
     }
-    func getLocations() {
-        discoverInteractor.fetchLocations { [weak self] result in
-            switch result {
-            case .success(let data):
-                self?.delegate?.presentLocation(_BaseDiscoverPresenter: self!, data: data.locations)
-            case .failure(let error):
-                print(error.localizedDescription)
-                self?.delegate?.presentFailureMessageFromLocation(_BaseDiscoverPresenter: self!, error: error.localizedDescription)
-            }
-        }
+    func getLocations() async throws {
+        let locations = try await discoverInteractor.fetchLocations()
+        delegate?.presentLocation(_BaseDiscoverPresenter: self, data: locations.locations)
+//        discoverInteractor.fetchLocations { [weak self] result in
+//            switch result {
+//            case .success(let data):
+//                self?.delegate?.presentLocation(_BaseDiscoverPresenter: self!, data: data.locations)
+//            case .failure(let error):
+//                print(error.localizedDescription)
+//                self?.delegate?.presentFailureMessageFromLocation(_BaseDiscoverPresenter: self!, error: error.localizedDescription)
+//            }
+//        }
     }
     
     func didTapLocation(atIndex : Int) {

--- a/Travl.iOS/Module/Discover/Presenter/ItenaryPresenter.swift
+++ b/Travl.iOS/Module/Discover/Presenter/ItenaryPresenter.swift
@@ -21,15 +21,8 @@ final class ItenaryPresenter {
         self.delegate = delegate
     }
     
-    func getItenaries(forLocation location: String) {
-        discoverInteractor.fetchItenaries(location) { [weak self] result in
-            switch result {
-            case .success(let data):
-                self?.delegate?.presentItenaryData(_ItenaryPresenter: self!, with: data)
-            case .failure(let error):
-                print(error.localizedDescription)
-                self?.delegate?.presentFailureMessageFromItenary(_ItenaryPresenter: self!, error: error)
-            }
-        }
+    func getItenaries(forLocation location: String) async throws {
+        let itenaries = try await discoverInteractor.fetchItenaries(location)
+        delegate?.presentItenaryData(_ItenaryPresenter: self, with: itenaries.itenaries.days)
     }
 }

--- a/Travl.iOS/Module/Discover/View/BaseDiscoverVC.swift
+++ b/Travl.iOS/Module/Discover/View/BaseDiscoverVC.swift
@@ -26,7 +26,10 @@ final class BaseDiscoverVC : UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        presenter.getLocations()
+        Task {
+            try await         presenter.getLocations()
+        }
+
         renderView()
     }
     
@@ -123,6 +126,9 @@ extension BaseDiscoverVC {
         locationResult = []
         collectionView.reloadData()
         collectionView.refreshControl?.beginRefreshing()
-        presenter.getLocations()
+        Task {
+           try await presenter.getLocations()
+        }
+
     }
 }

--- a/Travl.iOS/Module/Discover/View/ItenaryVC.swift
+++ b/Travl.iOS/Module/Discover/View/ItenaryVC.swift
@@ -27,7 +27,7 @@ final class ItenaryVC : UIViewController {
     private var fpc : FloatingPanelController!
     private let discoverInteractor = DiscoverInteractor()
     
-  
+    
     
     //MARK: - Life Cycle
     override func viewDidLoad() {
@@ -37,7 +37,10 @@ final class ItenaryVC : UIViewController {
     }
     
     override func viewWillAppear(_ animated: Bool) {
-        presenter.getItenaries(forLocation: locationName?.itenaryName ?? "")
+        super.viewWillAppear(animated)
+        Task {
+            try await presenter.getItenaries(forLocation: locationName?.itenaryName ?? "")
+        }   
     }
     
     //MARK: - Action
@@ -48,7 +51,7 @@ final class ItenaryVC : UIViewController {
 
 //MARK: - Presenter Delegate
 extension ItenaryVC : ItenaryPresenterDelegate {
-
+    
     func presentItenaryData(_ItenaryPresenter: ItenaryPresenter, with data: [[Days]]) {
         self.delegate?.didSendItenaryData(self, with: data)
     }

--- a/Travl.iOS/Module/Planner/Presenter/BasePlannerPresenter.swift
+++ b/Travl.iOS/Module/Planner/Presenter/BasePlannerPresenter.swift
@@ -42,16 +42,9 @@ final class BasePlannerPresenter {
         coreDataManager.removeObjectContext(planner, completion: {})
     }
     
-    func fetchImages() {
-        plannerInteractor.fetchFooterImages { [weak self] result in
-            switch result {
-            case .success(let data):
-                let images = data.images
-                self?.delegate?.presentFetchImages(self!, data: images)
-            case .failure(let error):
-                self?.delegate?.presentFailureMessageFromImages(_BasePlannerPresenter: self!, error: error.rawValue)
-            }
-        }
+    func fetchImages() async throws {
+        let imageResponse = try await plannerInteractor.fetchFooterImages()
+        delegate?.presentFetchImages(self, data: imageResponse.images)
     }
     
     func didTapPlannerRow(atIndex index : Int) {

--- a/Travl.iOS/Module/Planner/View/BasePlannerVC.swift
+++ b/Travl.iOS/Module/Planner/View/BasePlannerVC.swift
@@ -31,7 +31,10 @@ final class BasePlannerVC: UIViewController {
         renderView()
         registerCustomNib()
         presenter.setViewDelegate(delegate: self)
-        presenter.fetchImages()
+        Task {
+            try await presenter.fetchImages()
+        }
+        
     }
     override func viewWillAppear(_ animated: Bool) {
         presenter.fetchPlanner()
@@ -111,7 +114,7 @@ extension BasePlannerVC : BasePlannerImageFooterDelegate {
 }
 //MARK: - Presenter Delegate
 extension BasePlannerVC : BasePlannerPresenterDelegate {
-
+    
     func presentToPlannerDetails(_ BasePlannerPresenter: BasePlannerPresenter, index: Int) {
         performSegue(withIdentifier: Constants.SegueIdentifier.goToPlannerDetails, sender: self)
         analytics.log(.viewCreatedPlanner(index: index))
@@ -173,7 +176,10 @@ extension BasePlannerVC {
         basePlannerTableView.reloadData()
         refreshControl.beginRefreshing()
         presenter.fetchPlanner()
-        presenter.fetchImages()
+        
+        Task {
+            try await  presenter.fetchImages()
+        }
     }
 }
 


### PR DESCRIPTION
### Background

- Since Async/Await were introduced in WWDC 2021, networking layer in app will migrate to Async/Await for structure concurrency instead of completion handler Result type


### Module involve in refactoring
- Networking
- Discover
- Planner